### PR TITLE
TAV-258: Rename directDebitRequirements to bacsRequirements in API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ case class InitRequest(
     address: Option[InitRequestAddress] = None,
     messages: Option[InitRequestMessages] = None, 
     customisationsUrl: Option[String] = None,
-    directDebitRequirements: Option[InitDirectDebitRequirements] = None,
+    bacsRequirements: Option[InitBACSRequirements] = None,
     timeoutConfig: Option[InitRequestTimeoutConfig])
 )
 ```
@@ -32,7 +32,7 @@ case class InitRequestTimeoutConfig(timeoutUrl: String, timeoutAmount: Int, time
 // timeoutUrl must be a relative url, or a full url with a host that has been allow-listed
 
 // This is passed to configure direct debit/credit payment support requirements. The default, if not specified, is to require both debit and credit support.
-case class InitDirectDebitRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
+case class InitBACSRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
 ```
 
 The init endpoint will respond in the following format:
@@ -89,7 +89,7 @@ Once the initiating call has been made and a `journeyId` retrieved, the journey 
 
 Control at this stage passes to `BAVFE` until the journey is complete. At the end of the journey, `BAVFE` calls back to the `continueUrl` (provided in the initiate call) to indicate to the client service that the journey is complete and results can be retrieved.
 
-It should be noted that the `InitDirectDebitRequirements` settings will influence how the form level validation is handled in `BAVFE`. If a requirement is not met, the journey will not be permitted to continue. 
+It should be noted that the `InitBACSRequirements` settings will influence how the form level validation is handled in `BAVFE`. If a requirement is not met, the journey will not be permitted to continue. 
 
 ### Complete the journey
 Once the `continueUrl` has been called by `BAVFE`, a call can be made to `/api/complete/:journeyId` to retrieve the results of the journey. The following data model describes the payload that is returned:

--- a/app/bankaccountverification/Journey.scala
+++ b/app/bankaccountverification/Journey.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification
 
-import bankaccountverification.DirectDebitRequirements.defaultDirectDebitRequirements
+import bankaccountverification.BACSRequirements.defaultBACSRequirements
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import bankaccountverification.connector.ReputationResponseEnum
@@ -27,17 +27,17 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 
-case class DirectDebitRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
-object DirectDebitRequirements {
-  val defaultDirectDebitRequirements = DirectDebitRequirements(true, true)
+case class BACSRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
+object BACSRequirements {
+  val defaultBACSRequirements = BACSRequirements(true, true)
 }
 
 
 case class Journey(id: BSONObjectID, authProviderId: Option[String], expiryDate: ZonedDateTime,
                    serviceIdentifier: String, continueUrl: String, data: Session, messages: Option[JsObject] = None,
-                   customisationsUrl: Option[String] = None, directDebitRequirements: Option[DirectDebitRequirements] = None, timeoutConfig: Option[TimeoutConfig] = None) {
+                   customisationsUrl: Option[String] = None, bacsRequirements: Option[BACSRequirements] = None, timeoutConfig: Option[TimeoutConfig] = None) {
 
-  def getDirectDebitConstraints: DirectDebitRequirements = directDebitRequirements.getOrElse(defaultDirectDebitRequirements)
+  def getBACSRequirements: BACSRequirements = bacsRequirements.getOrElse(defaultBACSRequirements)
 }
 
 object Journey {
@@ -68,7 +68,7 @@ object Journey {
   def createExpiring(id: BSONObjectID, authProviderId: Option[String], serviceIdentifier: String, continueUrl: String,
                      messages: Option[JsObject] = None, customisationsUrl: Option[String] = None,
                      address: Option[Address] = None, prepopulatedData: Option[PrepopulatedData] = None,
-                     directDebitConstraints: Option[DirectDebitRequirements] = None, timeoutConfig: Option[TimeoutConfig]): Journey =
+                     directDebitConstraints: Option[BACSRequirements] = None, timeoutConfig: Option[TimeoutConfig]): Journey =
     Journey(id, authProviderId, expiryDate, serviceIdentifier, continueUrl, createSession(address, prepopulatedData),
       messages, customisationsUrl, directDebitConstraints, timeoutConfig)
 
@@ -95,8 +95,8 @@ object Journey {
   implicit val timeoutConfigReads: Reads[TimeoutConfig] = Json.reads[TimeoutConfig]
   implicit val timeoutConfigWrites: Writes[TimeoutConfig] = Json.writes[TimeoutConfig]
 
-  implicit val directDebitConstraintsReads: Reads[DirectDebitRequirements] = Json.reads[DirectDebitRequirements]
-  implicit val directDebitConstraintsWrites: Writes[DirectDebitRequirements] = Json.writes[DirectDebitRequirements]
+  implicit val directDebitConstraintsReads: Reads[BACSRequirements] = Json.reads[BACSRequirements]
+  implicit val directDebitConstraintsWrites: Writes[BACSRequirements] = Json.writes[BACSRequirements]
 
   implicit val localDateTimeRead: Reads[ZonedDateTime] =
     (__ \ "$date").read[Long].map { dateTime =>
@@ -122,7 +122,7 @@ object Journey {
       .and((__ \ "data").read[Session])
       .and((__ \ "messages").readNullable[JsObject])
       .and((__ \ "customisationsUrl").readNullable[String])
-      .and((__ \ "directDebitConstraints").readNullable[DirectDebitRequirements])
+      .and((__ \ "directDebitConstraints").readNullable[BACSRequirements])
       .and((__ \ "timeoutConfig").readNullable[TimeoutConfig])(
         (
           id: BSONObjectID,
@@ -133,7 +133,7 @@ object Journey {
           data: Session,
           messages: Option[JsObject],
           customisationsUrl: Option[String],
-          directDebitConstraints: Option[DirectDebitRequirements],
+          directDebitConstraints: Option[BACSRequirements],
           timeoutConfig: Option[TimeoutConfig]
         ) => Journey.apply(id, authProviderId, expiryDate, serviceIdentifier, continueUrl, data, messages, customisationsUrl, directDebitConstraints, timeoutConfig)
       )
@@ -148,7 +148,7 @@ object Journey {
       .and((__ \ "data").write[Session])
       .and((__ \ "messages").writeNullable[JsObject])
       .and((__ \ "customisationsUrl").writeNullable[String])
-      .and((__ \ "directDebitConstraints").writeNullable[DirectDebitRequirements])
+      .and((__ \ "directDebitConstraints").writeNullable[BACSRequirements])
       .and((__ \ "timeoutConfig").writeNullable[TimeoutConfig]) {
         unlift(Journey.unapply)
       }

--- a/app/bankaccountverification/JourneyRepository.scala
+++ b/app/bankaccountverification/JourneyRepository.scala
@@ -66,7 +66,7 @@ class JourneyRepository @Inject()(component: ReactiveMongoComponent)
   def create(authProviderId: Option[String], serviceIdentifier: String, continueUrl: String,
              messages: Option[JsObject] = None, customisationsUrl: Option[String] = None,
              address: Option[Address] = None, prepopulatedData: Option[PrepopulatedData] = None,
-             directDebitConstraints: Option[DirectDebitRequirements], timeoutConfig: Option[TimeoutConfig])(implicit ec: ExecutionContext): Future[BSONObjectID] = {
+             directDebitConstraints: Option[BACSRequirements], timeoutConfig: Option[TimeoutConfig])(implicit ec: ExecutionContext): Future[BSONObjectID] = {
     val journeyId = BSONObjectID.generate()
 
     insert(Journey.createExpiring(journeyId, authProviderId, serviceIdentifier, continueUrl, messages, customisationsUrl,

--- a/app/bankaccountverification/api/ApiController.scala
+++ b/app/bankaccountverification/api/ApiController.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.api
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.web.AccountTypeRequestEnum.{Business, Personal}
 import bankaccountverification._
 
@@ -65,7 +65,7 @@ class ApiController @Inject()(appConfig: AppConfig, mcc: MessagesControllerCompo
                         init.customisationsUrl,
                         address = init.address.map(a => Address(a.lines, a.town, a.postcode)),
                         prepopulatedData,
-                        init.directDebitRequirements.map(ddc => DirectDebitRequirements(ddc.directDebitRequired, ddc.directCreditRequired)).orElse(Some(DirectDebitRequirements.defaultDirectDebitRequirements)),
+                        init.bacsRequirements.map(ddc => BACSRequirements(ddc.directDebitRequired, ddc.directCreditRequired)).orElse(Some(BACSRequirements.defaultBACSRequirements)),
                         init.timeoutConfig.map(tc => TimeoutConfig(tc.timeoutUrl, tc.timeoutAmount, tc.timeoutKeepAliveUrl))
                       )
                       .map { journeyId =>

--- a/app/bankaccountverification/api/InitRequest.scala
+++ b/app/bankaccountverification/api/InitRequest.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{JsObject, Json, OWrites, Reads}
 
 case class InitRequestTimeoutConfig(timeoutUrl: String, timeoutAmount: Int, timeoutKeepAliveUrl: Option[String])
 
-case class InitDirectDebitRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
+case class InitBACSRequirements(directDebitRequired: Boolean, directCreditRequired: Boolean)
 
 case class InitRequest(serviceIdentifier: String,
                        continueUrl: String,
@@ -29,7 +29,7 @@ case class InitRequest(serviceIdentifier: String,
                        address: Option[InitRequestAddress] = None,
                        messages: Option[InitRequestMessages] = None,
                        customisationsUrl: Option[String] = None,
-                       directDebitRequirements: Option[InitDirectDebitRequirements] = None,
+                       bacsRequirements: Option[InitBACSRequirements] = None,
                        timeoutConfig: Option[InitRequestTimeoutConfig])
 
 case class InitRequestPrepopulatedData(accountType: AccountTypeRequestEnum,
@@ -55,8 +55,8 @@ object InitRequest {
   implicit val timeoutConfigReads: Reads[InitRequestTimeoutConfig] = Json.reads[InitRequestTimeoutConfig]
   implicit val timeoutConfigWrites: OWrites[InitRequestTimeoutConfig] = Json.writes[InitRequestTimeoutConfig]
 
-  implicit val directDebitConstraintsReads: Reads[InitDirectDebitRequirements] = Json.reads[InitDirectDebitRequirements]
-  implicit val directDebitConstraintsWrites: OWrites[InitDirectDebitRequirements] = Json.writes[InitDirectDebitRequirements]
+  implicit val directDebitConstraintsReads: Reads[InitBACSRequirements] = Json.reads[InitBACSRequirements]
+  implicit val directDebitConstraintsWrites: OWrites[InitBACSRequirements] = Json.writes[InitBACSRequirements]
 
   implicit val writes: OWrites[InitRequest] = Json.writes[InitRequest]
   implicit val reads: Reads[InitRequest] = Json.reads[InitRequest]

--- a/app/bankaccountverification/connector/BarsAssessResponse.scala
+++ b/app/bankaccountverification/connector/BarsAssessResponse.scala
@@ -27,8 +27,8 @@ case class BarsPersonalAssessSuccessResponse(accountNumberWithSortCodeIsValid: R
                                              nonConsented: ReputationResponseEnum,
                                              subjectHasDeceased: ReputationResponseEnum,
                                              sortCodeIsPresentOnEISCD: ReputationResponseEnum,
-                                             directDebitSupported: ReputationResponseEnum,
-                                             directCreditSupported: ReputationResponseEnum,
+                                             sortCodeSupportsDirectDebit: ReputationResponseEnum,
+                                             sortCodeSupportsDirectCredit: ReputationResponseEnum,
                                              nonStandardAccountDetailsRequiredForBacs: Option[ReputationResponseEnum],
                                              sortCodeBankName: Option[String]) extends BarsPersonalAssessResponse
 
@@ -46,15 +46,15 @@ object BarsPersonalAssessResponse {
 sealed trait BarsBusinessAssessResponse {}
 
 case class BarsBusinessAssessSuccessResponse(accountNumberWithSortCodeIsValid: ReputationResponseEnum,
-                                      sortCodeIsPresentOnEISCD: ReputationResponseEnum,
-                                      sortCodeBankName: Option[String],
-                                      accountExists: ReputationResponseEnum,
-                                      companyNameMatches: ReputationResponseEnum,
-                                      companyPostCodeMatches: ReputationResponseEnum,
-                                      companyRegistrationNumberMatches: ReputationResponseEnum,
-                                      directDebitSupported: ReputationResponseEnum,
-                                      directCreditSupported: ReputationResponseEnum,
-                                      nonStandardAccountDetailsRequiredForBacs: Option[ReputationResponseEnum]) extends BarsBusinessAssessResponse
+                                             sortCodeIsPresentOnEISCD: ReputationResponseEnum,
+                                             sortCodeBankName: Option[String],
+                                             accountExists: ReputationResponseEnum,
+                                             companyNameMatches: ReputationResponseEnum,
+                                             companyPostCodeMatches: ReputationResponseEnum,
+                                             companyRegistrationNumberMatches: ReputationResponseEnum,
+                                             sortCodeSupportsDirectDebit: ReputationResponseEnum,
+                                             sortCodeSupportsDirectCredit: ReputationResponseEnum,
+                                             nonStandardAccountDetailsRequiredForBacs: Option[ReputationResponseEnum]) extends BarsBusinessAssessResponse
 
 case class BarsBusinessAssessBadRequestResponse(code: String, desc: String) extends BarsBusinessAssessResponse
 

--- a/app/bankaccountverification/web/VerificationService.scala
+++ b/app/bankaccountverification/web/VerificationService.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.connector._
 import bankaccountverification.web.business.BusinessVerificationRequest
 import bankaccountverification.web.personal.PersonalVerificationRequest
@@ -47,7 +47,7 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
       address.map(a => BarsAddress(a.lines, a.town, a.postcode)))
 
   def processPersonalAssessResponse(journeyId: BSONObjectID,
-                                    directDebitConstraints: DirectDebitRequirements,
+                                    directDebitConstraints: BACSRequirements,
                                     assessResponse: Try[BarsPersonalAssessResponse],
                                     form: Form[PersonalVerificationRequest]
                                    )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Form[PersonalVerificationRequest]] = {
@@ -81,7 +81,7 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
       address.map(a => BarsAddress(a.lines, a.town, a.postcode)))
 
   def processBusinessAssessResponse(journeyId: BSONObjectID,
-                                    directDebitConstraints: DirectDebitRequirements,
+                                    directDebitConstraints: BACSRequirements,
                                     assessResponse: Try[BarsBusinessAssessResponse],
                                     form: Form[BusinessVerificationRequest]
                                    )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Form[BusinessVerificationRequest]] = {

--- a/app/bankaccountverification/web/business/BusinessVerificationController.scala
+++ b/app/bankaccountverification/web/business/BusinessVerificationController.scala
@@ -20,7 +20,7 @@ import bankaccountverification.connector.BarsBusinessAssessSuccessResponse
 import bankaccountverification.connector.ReputationResponseEnum.Yes
 import bankaccountverification.web.business.html.{BusinessAccountDetailsView, BusinessAccountExistsIndeterminate}
 import bankaccountverification.web.{ActionWithCustomisationsProvider, VerificationService}
-import bankaccountverification.{AppConfig, DirectDebitRequirements, RemoteMessagesApiProvider}
+import bankaccountverification.{AppConfig, BACSRequirements, RemoteMessagesApiProvider}
 
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
@@ -97,7 +97,7 @@ class BusinessVerificationController @Inject()(val appConfig: AppConfig,
       else
         for {
           response <- verificationService.assessBusiness(form.get, journey.data.address)
-          updatedForm <- verificationService.processBusinessAssessResponse(journey.id, journey.directDebitRequirements.getOrElse(DirectDebitRequirements.defaultDirectDebitRequirements), response, form)
+          updatedForm <- verificationService.processBusinessAssessResponse(journey.id, journey.bacsRequirements.getOrElse(BACSRequirements.defaultBACSRequirements), response, form)
         } yield
           updatedForm match {
             case uform if uform.hasErrors =>

--- a/app/bankaccountverification/web/business/BusinessVerificationRequest.scala
+++ b/app/bankaccountverification/web/business/BusinessVerificationRequest.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web.business
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.connector.ReputationResponseEnum.{Inapplicable, Indeterminate, No, Yes}
 import bankaccountverification.connector.{BarsBusinessAssessBadRequestResponse, BarsBusinessAssessResponse,
   BarsBusinessAssessSuccessResponse, ReputationResponseEnum}
@@ -47,7 +47,7 @@ object BusinessVerificationRequest {
 
   implicit class ValidationFormWrapper(form: Form[BusinessVerificationRequest]) {
     def validateUsingBarsBusinessAssessResponse(response: BarsBusinessAssessResponse,
-                                                directDebitConstraints: DirectDebitRequirements)
+                                                directDebitConstraints: BACSRequirements)
     : Form[BusinessVerificationRequest] =
       response match {
         case badRequest: BarsBusinessAssessBadRequestResponse =>
@@ -58,9 +58,9 @@ object BusinessVerificationRequest {
             form.fill(form.get).withError("accountNumber", "error.accountNumber.modCheckFailed")
           } else if (sortCodeIsPresentOnEISCD != Yes) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
-          } else if (directDebitSupported != Yes && directDebitConstraints.directDebitRequired) {
+          } else if (sortCodeSupportsDirectDebit != Yes && directDebitConstraints.directDebitRequired) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
-          } else if (directCreditSupported != Yes && directDebitConstraints.directCreditRequired) {
+          } else if (sortCodeSupportsDirectCredit != Yes && directDebitConstraints.directCreditRequired) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
           } else if (accountExists == No) {
             form.fill(form.get).withError("accountNumber", "error.accountNumber.doesNotExist")

--- a/app/bankaccountverification/web/personal/PersonalVerificationController.scala
+++ b/app/bankaccountverification/web/personal/PersonalVerificationController.scala
@@ -98,7 +98,7 @@ class PersonalVerificationController @Inject()(val appConfig: AppConfig, mcc: Me
         val verificationRequestFromForm = PersonalVerificationRequest.convertNameToASCII(form.get)
         for {
           response <- verificationService.assessPersonal(verificationRequestFromForm, journey.data.address)
-          updatedForm <- verificationService.processPersonalAssessResponse(journey.id, journey.getDirectDebitConstraints, response, form)
+          updatedForm <- verificationService.processPersonalAssessResponse(journey.id, journey.getBACSRequirements, response, form)
         } yield
           updatedForm match {
             case uform if uform.hasErrors =>

--- a/app/bankaccountverification/web/personal/PersonalVerificationRequest.scala
+++ b/app/bankaccountverification/web/personal/PersonalVerificationRequest.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web.personal
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.connector.ReputationResponseEnum.{Inapplicable, Indeterminate, No, Yes}
 import bankaccountverification.connector.{BarsPersonalAssessBadRequestResponse, BarsPersonalAssessResponse, BarsPersonalAssessSuccessResponse, ReputationResponseEnum}
 import bankaccountverification.web.Forms._
@@ -48,7 +48,7 @@ object PersonalVerificationRequest {
   }
 
   implicit class ValidationFormWrapper(form: Form[PersonalVerificationRequest]) {
-    def validateUsingBarsPersonalAssessResponse(response: BarsPersonalAssessResponse, directDebitConstraints: DirectDebitRequirements): Form[PersonalVerificationRequest] =
+    def validateUsingBarsPersonalAssessResponse(response: BarsPersonalAssessResponse, directDebitConstraints: BACSRequirements): Form[PersonalVerificationRequest] =
       response match {
         case badRequest: BarsPersonalAssessBadRequestResponse if badRequest.code == "SORT_CODE_ON_DENY_LIST" =>
           form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
@@ -61,9 +61,9 @@ object PersonalVerificationRequest {
             form.fill(form.get).withError("accountNumber", "error.accountNumber.modCheckFailed")
           else if (sortCodeIsPresentOnEISCD != Yes) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
-          } else if(directDebitSupported != Yes && directDebitConstraints.directDebitRequired) {
+          } else if(sortCodeSupportsDirectDebit != Yes && directDebitConstraints.directDebitRequired) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
-          } else if(directCreditSupported != Yes && directDebitConstraints.directCreditRequired) {
+          } else if(sortCodeSupportsDirectCredit != Yes && directDebitConstraints.directCreditRequired) {
             form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
           } else if (accountExists == No)
           form.fill(form.get).withError("accountNumber", "error.accountNumber.doesNotExist")

--- a/it/bankaccountverification/BankAccountVerificationITSpec.scala
+++ b/it/bankaccountverification/BankAccountVerificationITSpec.scala
@@ -143,7 +143,7 @@ class BankAccountVerificationITSpec() extends AnyWordSpec with GuiceOneServerPer
       serviceIdentifier = "serviceIdentifier",
       continueUrl = "continueUrl",
       address = Some(InitRequestAddress(List("Line 1", "Line 2"), Some("Town"), Some("Postcode"))),
-      directDebitRequirements = Some(InitDirectDebitRequirements(true, false)),
+      bacsRequirements = Some(InitBACSRequirements(true, false)),
       timeoutConfig = Some(InitRequestTimeoutConfig("url", 100, None)))
 
     val initResponse =

--- a/it/bankaccountverification/JourneyRepositoryITSpec.scala
+++ b/it/bankaccountverification/JourneyRepositoryITSpec.scala
@@ -1,7 +1,7 @@
 package bankaccountverification
 
-import bankaccountverification.DirectDebitRequirements
-import bankaccountverification.api.InitDirectDebitRequirements
+import bankaccountverification.BACSRequirements
+import bankaccountverification.api.InitBACSRequirements
 
 import java.time.ZonedDateTime
 import bankaccountverification.web.AccountTypeRequestEnum.{Business, Personal}
@@ -30,7 +30,7 @@ class JourneyRepositoryITSpec extends AnyWordSpec with Matchers with GuiceOneSer
       val journeyId = await(repository.create(Some("1234"), "serviceIndentifier", "continueUrl", None, None,
         Some(Address(List("Line 1", "Line 2"), Some("Town"), Some("HP1 1HP"))),
         Some(PrepopulatedData(Personal, Some("Bob"), Some("123456"), Some("12345678"), Some("A123"))),
-        Some(DirectDebitRequirements(true, true)), Some(TimeoutConfig("url", 100, None))))
+        Some(BACSRequirements(true, true)), Some(TimeoutConfig("url", 100, None))))
 
       val journey = await(repository.findById(journeyId))
       val timeoutConfig = journey.flatMap(j => j.timeoutConfig)
@@ -48,7 +48,7 @@ class JourneyRepositoryITSpec extends AnyWordSpec with Matchers with GuiceOneSer
       val journeyId = await(repository.create(Some("1234"), "serviceIndentifier", "continueUrl", None, None,
         Some(Address(List("Line 1", "Line 2"), Some("Town"), Some("HP1 1HP"))),
         Some(PrepopulatedData(Business, Some("Bob"), Some("123456"), Some("12345678"), Some("A123"))),
-        Some(DirectDebitRequirements(true, true)), Some(TimeoutConfig("url", 100, None))))
+        Some(BACSRequirements(true, true)), Some(TimeoutConfig("url", 100, None))))
 
       val journey = await(repository.findById(journeyId))
       val timeoutConfig = journey.flatMap(j => j.timeoutConfig)

--- a/test/bankaccountverification/api/ApiControllerSpec.scala
+++ b/test/bankaccountverification/api/ApiControllerSpec.scala
@@ -87,7 +87,7 @@ class ApiControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with
             meq(None),
             meq(Some(Address(List("Line 1", "Line 2"), Some("Town"), Some("Postcode")))),
             meq(None),
-            meq(Some(DirectDebitRequirements.defaultDirectDebitRequirements)),
+            meq(Some(BACSRequirements.defaultBACSRequirements)),
             meq(Some(TimeoutConfig("url", 100, None)))
           )(any())
         ).thenReturn(Future.successful(newJourneyId))
@@ -123,7 +123,7 @@ class ApiControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with
             meq(None),
             meq(Some(Address(List("Line 1", "Line 2"), Some("Town"), Some("Postcode")))),
             meq(Some(PrepopulatedData(Personal, Some("Bob"), Some("123456"), Some("12345678"), Some("A123")))),
-            meq(Some(DirectDebitRequirements.defaultDirectDebitRequirements)),
+            meq(Some(BACSRequirements.defaultBACSRequirements)),
             meq(Some(TimeoutConfig("url", 100, None)))
           )(any())
         ).thenReturn(Future.successful(newJourneyId))

--- a/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
+++ b/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
@@ -130,8 +130,8 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
               |  "nonConsented": "indeterminate",
               |  "subjectHasDeceased": "indeterminate",
               |  "sortCodeIsPresentOnEISCD": "yes",
-              |  "directDebitSupported": "yes",
-              |  "directCreditSupported": "yes",
+              |  "sortCodeSupportsDirectDebit": "yes",
+              |  "sortCodeSupportsDirectCredit": "yes",
               |  "nonStandardAccountDetailsRequiredForBacs": "no"
               |}""".stripMargin).withHeaders("Content-Type" -> "application/json"))
         }
@@ -228,8 +228,8 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
             """{
               |  "accountNumberWithSortCodeIsValid": "yes",
               |  "sortCodeIsPresentOnEISCD": "yes",
-              |  "directDebitSupported": "yes",
-              |  "directCreditSupported": "yes",
+              |  "sortCodeSupportsDirectDebit": "yes",
+              |  "sortCodeSupportsDirectCredit": "yes",
               |  "sortCodeBankName": "Some Company",
               |  "accountExists": "yes",
               |  "companyNameMatches": "yes",

--- a/test/bankaccountverification/web/JourneyJsonSerializationSpec.scala
+++ b/test/bankaccountverification/web/JourneyJsonSerializationSpec.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 
 import java.time.{ZoneOffset, ZonedDateTime}
 import bankaccountverification.connector.ReputationResponseEnum._
@@ -57,7 +57,7 @@ class JourneyJsonSerializationSpec extends AnyWordSpec with Matchers {
           )),
           business = None
         ),
-        directDebitRequirements = Some(DirectDebitRequirements(true, false)),
+        bacsRequirements = Some(BACSRequirements(true, false)),
         timeoutConfig = Some(TimeoutConfig("url", 100, Some("keepAlive")))
       )
 
@@ -139,7 +139,7 @@ class JourneyJsonSerializationSpec extends AnyWordSpec with Matchers {
           )),
           personal = None
         ),
-        directDebitRequirements = Some(DirectDebitRequirements(false, true)),
+        bacsRequirements = Some(BACSRequirements(false, true)),
         timeoutConfig = Some(TimeoutConfig("url", 100, Some("keepAlive")))
       )
 

--- a/test/bankaccountverification/web/VerificationServiceSpec.scala
+++ b/test/bankaccountverification/web/VerificationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.{Address, BusinessAccountDetails, JourneyRepository, PersonalAccountDetails, PersonalSession, Session}
 import bankaccountverification.connector.{BankAccountReputationConnector, BarsAddress, BarsBusinessAssessBadRequestResponse, BarsBusinessAssessResponse, BarsBusinessAssessSuccessResponse, BarsPersonalAssessBadRequestResponse, BarsPersonalAssessResponse, BarsPersonalAssessSuccessResponse, BarsValidationRequest, BarsValidationResponse}
 import bankaccountverification.connector.ReputationResponseEnum._
@@ -216,7 +216,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
 
       when(mockRepository.updatePersonalAccountDetails(any(), any())(any(), any())).thenReturn(Future.successful(true))
 
-      val res = await(service.processPersonalAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
+      val res = await(service.processPersonalAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
 
       "persist the details to mongo" in {
         val expectedAccountDetails = PersonalAccountDetails(
@@ -253,7 +253,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       val assessResult = Failure(new HttpException("FIRE IN SERVER ROOM", 500))
       when(mockRepository.updatePersonalAccountDetails(any(), any())(any(), any())).thenReturn(Future.successful(true))
 
-      val res = await(service.processPersonalAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
+      val res = await(service.processPersonalAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
 
       "persist the details to mongo" in {
         val expectedAccountDetails = PersonalAccountDetails(
@@ -287,7 +287,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       val form = PersonalVerificationRequest.form.fillAndValidate(userInput)
 
       val assessResult = Success(BarsPersonalAssessBadRequestResponse("SORT_CODE_ON_DENY_LIST", "083200: sort code is in deny list"))
-      val updatedForm = service.processPersonalAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
+      val updatedForm = service.processPersonalAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
 
       "return an invalid form" in {
         val result = await(updatedForm)
@@ -305,7 +305,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       val form = PersonalVerificationRequest.form.fillAndValidate(userInput)
 
       val assessResult = Success(BarsPersonalAssessBadRequestResponse("MALFORMED_JSON", "bad char"))
-      val updatedForm = service.processPersonalAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
+      val updatedForm = service.processPersonalAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
 
       "return an invalid form" in {
         val result = await(updatedForm)
@@ -508,7 +508,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       clearInvocations(mockRepository)
       when(mockRepository.updateBusinessAccountDetails(any(), any())(any(), any())).thenReturn(Future.successful(true))
 
-      val updatedForm = await(service.processBusinessAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
+      val updatedForm = await(service.processBusinessAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form))
 
       "persist the details to mongo" in {
         val expectedAccountDetails = BusinessAccountDetails(
@@ -543,7 +543,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       val assessResult = Failure(new HttpException("FIRE IN SERVER ROOM", 500))
       when(mockRepository.updateBusinessAccountDetails(any(), any())(any(), any())).thenReturn(Future.successful(true))
 
-      val updatedForm = service.processBusinessAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
+      val updatedForm = service.processBusinessAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
 
       "persist the details to mongo" in {
         val expectedAccountDetails = BusinessAccountDetails(
@@ -575,7 +575,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       val form = BusinessVerificationRequest.form.fillAndValidate(userInput)
 
       val assessResult = Success(BarsBusinessAssessBadRequestResponse("SORT_CODE_ON_DENY_LIST", "083200: sort code is in deny list"))
-      val updatedForm = service.processBusinessAssessResponse(journeyId, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
+      val updatedForm = service.processBusinessAssessResponse(journeyId, BACSRequirements(directDebitRequired = true, directCreditRequired = true), assessResult, form)
 
       "return an invalid form" in {
         await(updatedForm).hasErrors shouldEqual true

--- a/test/bankaccountverification/web/business/BusinessVerificationRequestSpec.scala
+++ b/test/bankaccountverification/web/business/BusinessVerificationRequestSpec.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web.business
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Yes}
 import bankaccountverification.connector.{BarsBusinessAssessBadRequestResponse, BarsBusinessAssessErrorResponse, BarsBusinessAssessResponse, BarsBusinessAssessSuccessResponse, ReputationResponseEnum}
 import com.codahale.metrics.SharedMetricRegistries
@@ -293,7 +293,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         No, No,
         Some(No)
       )
-      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the account number" in {
         updatedForm.error("accountNumber") shouldBe Some(
@@ -315,7 +315,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(No)
       )
 
-      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the account number" in {
         updatedForm.error("accountNumber") shouldBe Some(
@@ -336,7 +336,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Yes, Yes,
         Some(Yes)
       )
-      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the roll number field" in {
         updatedForm.error("rollNumber") shouldBe Some(FormError("rollNumber", "error.rollNumber.required"))
@@ -359,7 +359,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Yes, Yes,
         Some(Yes)
       )
-      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag no errors" in {
         updatedForm.hasErrors shouldBe false
@@ -382,7 +382,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         No, No,
         None
       )
-      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag errors" in {
         updatedForm.hasErrors shouldBe true
@@ -406,7 +406,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         No, Yes,
         None
       )
-      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag errors" in {
         updatedForm.hasErrors shouldBe true
@@ -430,7 +430,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Yes, No,
         None
       )
-      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = formWithRollNumber.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag errors" in {
         updatedForm.hasErrors shouldBe true
@@ -451,7 +451,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(ReputationResponseEnum.Error)
       )
 
-      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag no errors so that the journey is not impacted" in {
         updatedForm.hasErrors shouldBe false
@@ -460,7 +460,7 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
 
     "the response indicates that the sort code provided was on the deny list" should {
       val response = BarsBusinessAssessBadRequestResponse("SORT_CODE_ON_DENY_LIST", "083200: sort code is in deny list")
-      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsBusinessAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the sort code field" in {
         updatedForm.error("sortCode") shouldBe Some(FormError("sortCode", "error.sortCode.denyListed"))

--- a/test/bankaccountverification/web/personal/PersonalVerificationRequestSpec.scala
+++ b/test/bankaccountverification/web/personal/PersonalVerificationRequestSpec.scala
@@ -16,7 +16,7 @@
 
 package bankaccountverification.web.personal
 
-import bankaccountverification.DirectDebitRequirements
+import bankaccountverification.BACSRequirements
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Yes}
 import bankaccountverification.connector.{BarsPersonalAssessBadRequestResponse, BarsPersonalAssessSuccessResponse, BarsValidationResponse, ReputationResponseEnum}
 import com.codahale.metrics.SharedMetricRegistries
@@ -285,7 +285,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(No),
         None
       )
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the account number" in {
         updatedForm.error("accountNumber") shouldBe Some(
@@ -307,7 +307,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(No),
         None
       )
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the sort code" in {
         updatedForm.error("sortCode") shouldBe Some(
@@ -329,7 +329,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(No),
         None
       )
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the sort code" in {
         updatedForm.error("sortCode") shouldBe Some(
@@ -351,7 +351,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(No),
         None
       )
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the sort code" in {
         updatedForm.error("sortCode") shouldBe Some(
@@ -374,7 +374,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         None
       )
 
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the account number" in {
         updatedForm.error("accountNumber") shouldBe Some(
@@ -396,7 +396,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(Yes),
         None
       )
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the roll number field" in {
         updatedForm.error("rollNumber") shouldBe Some(FormError("rollNumber", "error.rollNumber.required"))
@@ -419,7 +419,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         Some(Yes),
         None
       )
-      val updatedForm = formWithRollNumber.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = formWithRollNumber.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag no errors" in {
         updatedForm.hasErrors shouldBe false
@@ -440,7 +440,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
         None
       )
 
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag no errors so that the journey is not impacted" in {
         updatedForm.hasErrors shouldBe false
@@ -449,7 +449,7 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
 
     "the response indicates that the sort code provided was on the deny list" should {
       val response = BarsPersonalAssessBadRequestResponse("SORT_CODE_ON_DENY_LIST", "083200: sort code is in deny list")
-      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, DirectDebitRequirements(directDebitRequired = true, directCreditRequired = true))
+      val updatedForm = form.validateUsingBarsPersonalAssessResponse(response, BACSRequirements(directDebitRequired = true, directCreditRequired = true))
 
       "flag an error against the sort code field" in {
         updatedForm.error("sortCode") shouldBe Some(FormError("sortCode", "error.sortCode.denyListed"))


### PR DESCRIPTION
& Renamed bars response fields to be the same as in bars.