### PR TITLE
CIR-2053 Update hmrc-mongo-play version to address bobby rule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import uk.gov.hmrc.DefaultBuildSettings
 
-ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / scalaVersion := "2.13.16"
 ThisBuild / majorVersion := 0
 
 val appName = "bank-account-verification-frontend"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,17 +2,18 @@ import sbt.*
 
 object AppDependencies {
   private val bootstrapPlayVersion = "8.4.0"
+  private val hmrcMongoPlayVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % "1.6.0",
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "8.5.0",
-    "uk.gov.hmrc" %% "play-partials-play-30" % "9.1.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoPlayVersion,
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "8.5.0",
+    "uk.gov.hmrc"       %% "play-partials-play-30"      % "9.1.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapPlayVersion % Test,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % "1.6.0" % Test,
-    "org.jsoup" % "jsoup" % "1.15.4" % Test,
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30"   % bootstrapPlayVersion  % Test,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"  % hmrcMongoPlayVersion  % Test,
+    "org.jsoup"          % "jsoup"                    % "1.19.1"              % Test
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.18.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.4.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")


### PR DESCRIPTION
This PR is to fix the bobby rule which will stop us from deploying this service on the 31st May 2025. There are platops-pr-bot suggestion on updating **_bootstrap-frontend-play_** which will be done on another JIRA ticket