### PR TITLE
CIR-2916 Uplift dependencies

### DIFF
--- a/app/bankaccountverification/JourneyRepository.scala
+++ b/app/bankaccountverification/JourneyRepository.scala
@@ -43,7 +43,7 @@ import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model.Indexes.ascending
 import org.mongodb.scala.model.Updates.{combine, set}
 import org.mongodb.scala.model.{IndexModel, IndexOptions}
-import play.api.libs.json.{JsObject, Json, OFormat, OWrites}
+import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 

--- a/app/bankaccountverification/api/ApiController.scala
+++ b/app/bankaccountverification/api/ApiController.scala
@@ -95,7 +95,7 @@ class ApiController @Inject()(appConfig: AppConfig,
                 logger.warn(s"Something bad happened: ${x.getMessage}", x)
                 Future.successful(InternalServerError)
               }
-          case Failure(e) => Future.successful(BadRequest)
+          case Failure(_) => Future.successful(BadRequest)
         }
     } recoverWith { case _ =>
       Future.successful(Unauthorized)

--- a/app/bankaccountverification/api/ApiV2Controller.scala
+++ b/app/bankaccountverification/api/ApiV2Controller.scala
@@ -131,7 +131,7 @@ class ApiV2Controller @Inject()(appConfig: AppConfig, accessChecker: AccessCheck
                 logger.warn(s"Something bad happened: ${x.getMessage}", x)
                 Future.successful(InternalServerError)
               }
-          case Failure(e) => Future.successful(BadRequest)
+          case Failure(_) => Future.successful(BadRequest)
         }
     } recoverWith { case _ =>
       Future.successful(Unauthorized)

--- a/app/bankaccountverification/api/ApiV3Controller.scala
+++ b/app/bankaccountverification/api/ApiV3Controller.scala
@@ -131,7 +131,7 @@ class ApiV3Controller @Inject()(appConfig: AppConfig, accessChecker: AccessCheck
                 logger.warn(s"Something bad happened: ${x.getMessage}", x)
                 Future.successful(InternalServerError)
               }
-          case Failure(e) => Future.successful(BadRequest)
+          case Failure(_) => Future.successful(BadRequest)
         }
     } recoverWith { case e =>
       Future.successful(Unauthorized(e.getMessage))

--- a/app/bankaccountverification/connector/BankAccountReputationConnector.scala
+++ b/app/bankaccountverification/connector/BankAccountReputationConnector.scala
@@ -64,7 +64,7 @@ class BankAccountReputationConnector @Inject()(httpClient: HttpClientV2, appConf
       }
   }
 
-  def assessBusiness(companyName: String, companyRegistrationNumber: Option[String], sortCode: String,
+  def assessBusiness(companyName: String, sortCode: String,
                      accountNumber: String, rollNumber: Option[String], address: Option[BarsAddress], callingClient: String)
                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Try[BarsBusinessAssessResponse]] = {
     import BarsBusinessAssessResponse.*

--- a/app/bankaccountverification/testOnly/TestSetupService.scala
+++ b/app/bankaccountverification/testOnly/TestSetupService.scala
@@ -21,7 +21,7 @@ import bankaccountverification.api.InitResponse
 import bankaccountverification.models.HttpErrorResponse
 import play.api.http.HeaderNames
 import play.api.http.Status.OK
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}

--- a/app/bankaccountverification/web/ErrorHandler.scala
+++ b/app/bankaccountverification/web/ErrorHandler.scala
@@ -21,7 +21,7 @@ import bankaccountverification.web.views.html.ErrorTemplate
 
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Request, RequestHeader}
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 

--- a/app/bankaccountverification/web/Forms.scala
+++ b/app/bankaccountverification/web/Forms.scala
@@ -103,7 +103,7 @@ object Forms {
 
   private def sortcodeHasInvalidChars(sortcode: String): Boolean =
     Try(sortcode.toInt) match {
-      case Success(sc) => false
+      case Success(_) => false
       case Failure(_) => true
     }
 }

--- a/app/bankaccountverification/web/VerificationService.scala
+++ b/app/bankaccountverification/web/VerificationService.scala
@@ -56,7 +56,7 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
     val (updatedForm, response) = assessResponse match {
       case Success(response) =>
         (form.validateUsingBarsPersonalAssessResponse(response, directDebitConstraints), response)
-      case Failure(e) =>
+      case Failure(_) =>
         logger.warn("Received error response from bank-account-reputation.assess.personal")
         (form, BarsPersonalAssessErrorResponse())
     }
@@ -89,7 +89,7 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
 
     val (updatedForm, response) = assessResponse match {
       case Success(response) => (form.validateUsingBarsBusinessAssessResponse(response, directDebitConstraints), response)
-      case Failure(e) =>
+      case Failure(_) =>
         logger.warn("Received error response from bank-account-reputation.assess.business")
         (form, BarsBusinessAssessErrorResponse())
     }

--- a/app/bankaccountverification/web/VerificationService.scala
+++ b/app/bankaccountverification/web/VerificationService.scala
@@ -64,8 +64,6 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
     updatedForm.fold(
       formWithErrors => Future.successful(formWithErrors),
       verificationRequest => {
-        import bankaccountverification.Journey._
-
         val accountDetails = PersonalAccountDetails(verificationRequest, response)
         repository.updatePersonalAccountDetails(journeyId, accountDetails).map(_ => form)
       }
@@ -99,8 +97,6 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
     updatedForm.fold(
       formWithErrors => Future.successful(formWithErrors),
       verificationRequest => {
-        import bankaccountverification.Journey._
-
         val accountDetails = BusinessAccountDetails(verificationRequest, response)
         repository.updateBusinessAccountDetails(journeyId, accountDetails).map(_ => form)
       }

--- a/app/bankaccountverification/web/VerificationService.scala
+++ b/app/bankaccountverification/web/VerificationService.scala
@@ -74,7 +74,6 @@ class VerificationService @Inject()(connector: BankAccountReputationConnector, r
                     (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Try[BarsBusinessAssessResponse]] =
     connector.assessBusiness(
       request.companyName,
-      None,
       request.sortCode,
       request.accountNumber,
       request.rollNumber,

--- a/app/bankaccountverification/web/business/BusinessVerificationRequest.scala
+++ b/app/bankaccountverification/web/business/BusinessVerificationRequest.scala
@@ -50,7 +50,7 @@ object BusinessVerificationRequest {
                                                 directDebitConstraints: BACSRequirements)
     : Form[BusinessVerificationRequest] =
       response match {
-        case badRequest: BarsBusinessAssessBadRequestResponse =>
+        case _: BarsBusinessAssessBadRequestResponse =>
           form.fill(form.get).withError("sortCode", "error.sortCode.denyListed")
         case success: BarsBusinessAssessSuccessResponse =>
           import success._

--- a/app/bankaccountverification/web/views/AccountTypeView.scala.html
+++ b/app/bankaccountverification/web/views/AccountTypeView.scala.html
@@ -34,7 +34,7 @@
 ) {
     @if(accountTypeForm.hasErrors) {
         @errorSummary(ErrorSummary(title = HtmlContent(messages("error.summaryText")),
-            errorList = accountTypeForm.errors.map { error ⇒
+            errorList = accountTypeForm.errors.map { error =>
                 ErrorLink(href = Some(s"#${error.key}"),
                     content = HtmlContent(messages(error.message)))
             }))

--- a/app/bankaccountverification/web/views/Layout.scala.html
+++ b/app/bankaccountverification/web/views/Layout.scala.html
@@ -64,8 +64,8 @@
     @{
         if(!forceNavigation && welshTranslationsAvailable) {
             languageSelect(LanguageSelect(messages.lang.code match {
-                case "en" ⇒ En
-                case "cy" ⇒ Cy
+                case "en" => En
+                case "cy" => Cy
             }, En -> s"${bankaccountverification.web.routes.CustomLanguageController.switchToLanguage("english")}",
                 Cy -> s"${bankaccountverification.web.routes.CustomLanguageController.switchToLanguage("cymraeg")}"
             ))

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,9 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     PlayKeys.playDefaultPort := 9903,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
+    // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
+    // suppress warnings in generated routes files
+    scalacOptions += "-Wconf:src=routes/.*:s",
     TwirlKeys.templateImports ++= Seq(
       "bankaccountverification.AppConfig",
       "uk.gov.hmrc.govukfrontend.views.html.components._",

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,7 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.govukfrontend.views.html.components._",
       "uk.gov.hmrc.hmrcfrontend.views.html.components._"
     ),
-    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
-    scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s",
+    scalacOptions += "-Wconf:msg=unused import&src=html/.*:s"
   )
 
 lazy val it = project.in(file("it"))

--- a/it/test/bankaccountverification/BankAccountVerificationITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationITSpec.scala
@@ -153,7 +153,7 @@ class BankAccountVerificationITSpec extends AnyWordSpec with GuiceOneServerPerSu
     when(mockAuthConnector.authorise(meq(EmptyPredicate), meq(AuthProviderId.retrieval))(any(), any()))
         .thenReturn(Future.successful("1234"))
 
-    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
+    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
       Future.successful(Success(BarsBusinessAssessSuccessResponse(Yes, Yes, Some("sort-code-bank-name-business"), Indeterminate, Partial, Yes, No, Some(No), None, Some("account-name")))))
 
     val wsClient = app.injector.instanceOf[WSClient]

--- a/it/test/bankaccountverification/BankAccountVerificationITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationITSpec.scala
@@ -97,33 +97,32 @@ class BankAccountVerificationITSpec extends AnyWordSpec with GuiceOneServerPerSu
     val atformData = Map("accountType" -> "personal")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-            .url(setAccountTypeUrl)
-            .withFollowRedirects(false)
-            .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-            .post(atformData)
-      )
+
+    await(
+      wsClient
+          .url(setAccountTypeUrl)
+          .withFollowRedirects(false)
+          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+          .post(atformData)
+    )
 
     val bankAccountDetails = PersonalVerificationRequest("some-account-name", "12-12-12", "12349876")
     val formData = getCCParams(bankAccountDetails) ++ Map("rollNumber" -> Seq())
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/personal/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-            .url(verifyUrl)
-            .withFollowRedirects(false)
-            .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-            .post(formData))
+
+    await(
+      wsClient
+          .url(verifyUrl)
+          .withFollowRedirects(false)
+          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+          .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
-
-    import bankaccountverification.connector.ReputationResponseEnum.*
+    
     val sessionDataMaybe = Json.fromJson[CompleteResponse](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteResponse](
@@ -181,13 +180,13 @@ class BankAccountVerificationITSpec extends AnyWordSpec with GuiceOneServerPerSu
     val atformData = Map("accountType" -> "business")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-            .url(setAccountTypeUrl)
-            .withFollowRedirects(false)
-            .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-            .post(atformData))
+
+    await(
+      wsClient
+          .url(setAccountTypeUrl)
+          .withFollowRedirects(false)
+          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+          .post(atformData))
 
     val bankAccountDetails =
       BusinessVerificationRequest("some-company-name", "12-12-12", "12349876", None)
@@ -195,19 +194,19 @@ class BankAccountVerificationITSpec extends AnyWordSpec with GuiceOneServerPerSu
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/business/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-            .url(verifyUrl)
-            .withFollowRedirects(false)
-            .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-            .post(formData))
+
+    await(
+      wsClient
+          .url(verifyUrl)
+          .withFollowRedirects(false)
+          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+          .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse =
       await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
-    import bankaccountverification.connector.ReputationResponseEnum.*
+
     val sessionDataMaybe = Json.fromJson[CompleteResponse](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteResponse](
@@ -264,20 +263,19 @@ class BankAccountVerificationITSpec extends AnyWordSpec with GuiceOneServerPerSu
     val verifyUrl = s"$baseUrl${response.detailsUrl.get}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-            .url(verifyUrl)
-            .withFollowRedirects(false)
-            .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-            .post(formData)
-      )
+
+    await(
+      wsClient
+          .url(verifyUrl)
+          .withFollowRedirects(false)
+          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+          .post(formData)
+    )
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
 
-    import bankaccountverification.connector.ReputationResponseEnum.*
     val sessionDataMaybe = Json.fromJson[CompleteResponse](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteResponse](

--- a/it/test/bankaccountverification/BankAccountVerificationV2ITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationV2ITSpec.scala
@@ -95,33 +95,32 @@ class BankAccountVerificationV2ITSpec extends AnyWordSpec with GuiceOneServerPer
     val atformData = Map("accountType" -> "personal")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-          .url(setAccountTypeUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-          .post(atformData)
-      )
+
+    await(
+      wsClient
+        .url(setAccountTypeUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+        .post(atformData)
+    )
 
     val bankAccountDetails = PersonalVerificationRequest("some-account-name", "12-12-12", "12349876")
     val formData = getCCParams(bankAccountDetails) ++ Map("rollNumber" -> Seq())
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/personal/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData))
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
 
-    import bankaccountverification.connector.ReputationResponseEnum.*
     val sessionDataMaybe = Json.fromJson[CompleteV2Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV2Response](
@@ -163,13 +162,13 @@ class BankAccountVerificationV2ITSpec extends AnyWordSpec with GuiceOneServerPer
     val atformData = Map("accountType" -> "business")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-          .url(setAccountTypeUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-          .post(atformData))
+
+    await(
+      wsClient
+        .url(setAccountTypeUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+        .post(atformData))
 
     val bankAccountDetails =
       BusinessVerificationRequest("some-company-name", "12-12-12", "12349876", None)
@@ -177,19 +176,19 @@ class BankAccountVerificationV2ITSpec extends AnyWordSpec with GuiceOneServerPer
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/business/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData))
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse =
       await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
-    import bankaccountverification.connector.ReputationResponseEnum.*
+
     val sessionDataMaybe = Json.fromJson[CompleteV2Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV2Response](
@@ -229,20 +228,19 @@ class BankAccountVerificationV2ITSpec extends AnyWordSpec with GuiceOneServerPer
     val verifyUrl = s"$baseUrl${response.detailsUrl.get}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData)
-      )
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData)
+    )
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
 
-    import bankaccountverification.connector.ReputationResponseEnum.*
     val sessionDataMaybe = Json.fromJson[CompleteV2Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV2Response](

--- a/it/test/bankaccountverification/BankAccountVerificationV2ITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationV2ITSpec.scala
@@ -137,7 +137,7 @@ class BankAccountVerificationV2ITSpec extends AnyWordSpec with GuiceOneServerPer
     when(mockAuthConnector.authorise(meq(EmptyPredicate), meq(AuthProviderId.retrieval))(any(), any()))
       .thenReturn(Future.successful("1234"))
 
-    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
+    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
       Future.successful(Success(BarsBusinessAssessSuccessResponse(Yes, Yes, Some("sort-code-bank-name-business"), Indeterminate, Partial, Yes, No, Some(No), None, Some("some-company")))))
 
     val wsClient = app.injector.instanceOf[WSClient]

--- a/it/test/bankaccountverification/BankAccountVerificationV3ITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationV3ITSpec.scala
@@ -137,7 +137,7 @@ class BankAccountVerificationV3ITSpec extends AnyWordSpec with GuiceOneServerPer
     when(mockAuthConnector.authorise(meq(EmptyPredicate), meq(AuthProviderId.retrieval))(any(), any()))
       .thenReturn(Future.successful("1234"))
 
-    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
+    when(mockBankAccountReputationConnector.assessBusiness(any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(
       Future.successful(Success(BarsBusinessAssessSuccessResponse(Yes, Yes, Some("sort-code-bank-name-business"), Indeterminate, Partial, Yes, No, Some(No), None, Some("some-company")))))
 
     val wsClient = app.injector.instanceOf[WSClient]

--- a/it/test/bankaccountverification/BankAccountVerificationV3ITSpec.scala
+++ b/it/test/bankaccountverification/BankAccountVerificationV3ITSpec.scala
@@ -95,33 +95,32 @@ class BankAccountVerificationV3ITSpec extends AnyWordSpec with GuiceOneServerPer
     val atformData = Map("accountType" -> "personal")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-          .url(setAccountTypeUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-          .post(atformData)
-      )
+
+    await(
+      wsClient
+        .url(setAccountTypeUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+        .post(atformData)
+    )
 
     val bankAccountDetails = PersonalVerificationRequest("some-account-name", "12-12-12", "12349876")
     val formData = getCCParams(bankAccountDetails) ++ Map("rollNumber" -> Seq())
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/personal/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData))
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
 
-    import bankaccountverification.connector.ReputationResponseEnum.*
     val sessionDataMaybe = Json.fromJson[CompleteV3Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV3Response](
@@ -163,13 +162,13 @@ class BankAccountVerificationV3ITSpec extends AnyWordSpec with GuiceOneServerPer
     val atformData = Map("accountType" -> "business")
     val setAccountTypeUrl = s"$baseUrl${response.startUrl}"
     val atrequest = FakeRequest().withCSRFToken
-    val setAccountTypeResponse =
-      await(
-        wsClient
-          .url(setAccountTypeUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
-          .post(atformData))
+
+    await(
+      wsClient
+        .url(setAccountTypeUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(atrequest.headers.toSimpleMap.toSeq: _*)
+        .post(atformData))
 
     val bankAccountDetails =
       BusinessVerificationRequest("some-company-name", "12-12-12", "12349876", Some("AB123"))
@@ -177,19 +176,19 @@ class BankAccountVerificationV3ITSpec extends AnyWordSpec with GuiceOneServerPer
     val verifyUrl = s"$baseUrl/bank-account-verification/verify/business/${response.journeyId}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData))
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData))
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse =
       await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
-    import bankaccountverification.connector.ReputationResponseEnum.*
+
     val sessionDataMaybe = Json.fromJson[CompleteV3Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV3Response](
@@ -229,20 +228,19 @@ class BankAccountVerificationV3ITSpec extends AnyWordSpec with GuiceOneServerPer
     val verifyUrl = s"$baseUrl${response.detailsUrl.get}"
 
     val request = FakeRequest().withCSRFToken
-    val verifyResponse =
-      await(
-        wsClient
-          .url(verifyUrl)
-          .withFollowRedirects(false)
-          .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
-          .post(formData)
-      )
+
+    await(
+      wsClient
+        .url(verifyUrl)
+        .withFollowRedirects(false)
+        .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+        .post(formData)
+    )
 
     val completeUrl = s"$baseUrl${response.completeUrl}"
     val completeResponse = await(wsClient.url(completeUrl).get())
     completeResponse.status shouldBe 200
 
-    import bankaccountverification.connector.ReputationResponseEnum.*
     val sessionDataMaybe = Json.fromJson[CompleteV3Response](completeResponse.json)
 
     sessionDataMaybe shouldBe JsSuccess[CompleteV3Response](

--- a/it/test/bankaccountverification/JourneyRepositoryITSpec.scala
+++ b/it/test/bankaccountverification/JourneyRepositoryITSpec.scala
@@ -29,7 +29,7 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 import java.time.temporal.ChronoUnit
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class JourneyRepositoryITSpec extends AnyWordSpec with Matchers with GuiceOneServerPerSuite with MockitoSugar {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,13 +3,14 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapPlayVersion = "10.7.0"
+  private val playFrontendVersion  = "12.32.0"
   private val hmrcMongoPlayVersion = "2.12.0"
   private val playSuffix           = "-play-30"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo$playSuffix"         % hmrcMongoPlayVersion,
     "uk.gov.hmrc"       %% s"bootstrap-frontend$playSuffix" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc$playSuffix" % "12.29.0",
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc$playSuffix" % playFrontendVersion,
     "uk.gov.hmrc"       %% s"play-partials$playSuffix"      % "10.2.0"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "10.5.0"
+  private val bootstrapPlayVersion = "10.7.0"
   private val hmrcMongoPlayVersion = "2.12.0"
   private val playSuffix           = "-play-30"
 

--- a/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
+++ b/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
@@ -16,16 +16,16 @@
 
 package bankaccountverification.connector
 
-import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Partial, Yes}
+import bankaccountverification.connector.ReputationResponseEnum.{No, Partial, Yes}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.Results._
-import play.api.routing.sird.{POST => SPOST, _}
-import play.api.test.Helpers._
+import play.api.mvc.Results.*
+import play.api.routing.sird.{POST as SPOST, *}
+import play.api.test.Helpers.*
 import play.core.server.{Server, ServerConfig}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -46,7 +46,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case r @ SPOST(p"/verify/personal") =>
             r.headers.get("True-Calling-Client") shouldBe Some("example-service")
@@ -75,7 +75,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 json response that differs from the expected format" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/personal") =>
             Action(
@@ -99,7 +99,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 non-json response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/personal") =>
             Action(Ok("NOJSON4U").withHeaders("Content-Type" -> "application/json"))
@@ -115,7 +115,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 400 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/personal") => Action(BadRequest(
             """{"code": "SORT_CODE_ON_DENY_LIST", "desc": "083200: sort code is in deny list"}"""))
@@ -131,7 +131,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 500 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/personal") => Action(InternalServerError)
         }
@@ -149,7 +149,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case r @ SPOST(p"/verify/business") =>
             r.headers.get("True-Calling-Client") shouldBe Some("example-service")
@@ -179,7 +179,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 json response that differs from the expected format" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/business") =>
             Action(
@@ -203,7 +203,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 200 non-json response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/business") =>
             Action(Ok("NOJSON4U").withHeaders("Content-Type" -> "application/json"))
@@ -219,7 +219,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 400 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/business") => Action(BadRequest(
             """{"code": "SORT_CODE_ON_DENY_LIST", "desc": "083200: sort code is in deny list"}"""))
@@ -235,7 +235,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
 
     "handle a 500 response" in {
       Server.withRouterFromComponents(ServerConfig(port = Some(barsPort))) { components =>
-        import components.{defaultActionBuilder => Action}
+        import components.defaultActionBuilder as Action
         {
           case SPOST(p"/verify/business") => Action(InternalServerError)
         }

--- a/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
+++ b/test/bankaccountverification/connector/BankAccountReputationConnectorSpec.scala
@@ -170,7 +170,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
         implicit val hc: HeaderCarrier = HeaderCarrier()
         val connector = app.injector.instanceOf[BankAccountReputationConnector]
 
-        val response = await(connector.assessBusiness("Some Company", None, "20-30-40", "12345678", None, None, "example-service"))
+        val response = await(connector.assessBusiness("Some Company", "20-30-40", "12345678", None, None, "example-service"))
         response shouldBe Success(
           BarsBusinessAssessSuccessResponse(Yes, Yes, Some("Some Bank"), Yes, Partial, Yes, Yes, Some(No), None, Some("Some Co."))
         )
@@ -196,7 +196,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
         implicit val hc: HeaderCarrier = HeaderCarrier()
         val connector = app.injector.instanceOf[BankAccountReputationConnector]
 
-        val response = await(connector.assessBusiness("Some Company", None, "20-30-40", "12345678", None, None, "example-service"))
+        val response = await(connector.assessBusiness("Some Company", "20-30-40", "12345678", None, None, "example-service"))
         response shouldBe a[Failure[_]]
       }
     }
@@ -212,7 +212,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
         implicit val hc: HeaderCarrier = HeaderCarrier()
         val connector = app.injector.instanceOf[BankAccountReputationConnector]
 
-        val response = await(connector.assessBusiness("Some Company", None, "20-30-40", "12345678", None, None, "example-service"))
+        val response = await(connector.assessBusiness("Some Company", "20-30-40", "12345678", None, None, "example-service"))
         response shouldBe a[Failure[_]]
       }
     }
@@ -228,7 +228,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
         implicit val hc: HeaderCarrier = HeaderCarrier()
         val connector = app.injector.instanceOf[BankAccountReputationConnector]
 
-        val response = await(connector.assessBusiness("Some Company", None, "20-30-40", "12345678", None, None, "example-service"))
+        val response = await(connector.assessBusiness("Some Company", "20-30-40", "12345678", None, None, "example-service"))
         response shouldBe a[Success[BarsBusinessAssessBadRequestResponse]]
       }
     }
@@ -243,7 +243,7 @@ class BankAccountReputationConnectorSpec extends AnyWordSpec with Matchers with 
         implicit val hc: HeaderCarrier = HeaderCarrier()
         val connector = app.injector.instanceOf[BankAccountReputationConnector]
 
-        val response = await(connector.assessBusiness("Some Company", None, "20-30-40", "12345678", None, None, "example-service"))
+        val response = await(connector.assessBusiness("Some Company", "20-30-40", "12345678", None, None, "example-service"))
         response shouldBe a[Failure[_]]
       }
     }

--- a/test/bankaccountverification/timeout/TimeoutControllerSpec.scala
+++ b/test/bankaccountverification/timeout/TimeoutControllerSpec.scala
@@ -16,14 +16,14 @@
 
 package bankaccountverification.timeout
 
-import bankaccountverification._
+import bankaccountverification.*
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Yes}
 import bankaccountverification.web.AccountTypeRequestEnum.Personal
 import bankaccountverification.web.TimeoutController
 import com.codahale.metrics.SharedMetricRegistries
 import org.bson.types.ObjectId
-import org.mockito.ArgumentMatchers.{eq => meq, _}
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{eq as meq, *}
+import org.mockito.Mockito.*
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -33,7 +33,7 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import play.api.{Application, Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
@@ -42,12 +42,9 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.time.Instant
 import scala.concurrent.Future
-import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class TimeoutControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with GuiceOneAppPerSuite with OptionValues {
-
-  implicit private val timeout: FiniteDuration = 1 second
 
   private val env = Environment.simple()
   private val configuration = Configuration.load(env)

--- a/test/bankaccountverification/web/AccountTypeControllerSpec.scala
+++ b/test/bankaccountverification/web/AccountTypeControllerSpec.scala
@@ -16,13 +16,13 @@
 
 package bankaccountverification.web
 
-import org.apache.pekko.stream.Materializer
-import bankaccountverification._
+import bankaccountverification.*
 import bankaccountverification.web.AccountTypeRequestEnum.Personal
 import com.codahale.metrics.SharedMetricRegistries
+import org.apache.pekko.stream.Materializer
 import org.bson.types.ObjectId
-import org.mockito.ArgumentMatchers.{eq => meq, _}
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{eq as meq, *}
+import org.mockito.Mockito.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -32,15 +32,15 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException}
 
+import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.time.{Instant, LocalDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class AccountTypeControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with GuiceOneAppPerSuite {

--- a/test/bankaccountverification/web/AccountTypeRequestSpec.scala
+++ b/test/bankaccountverification/web/AccountTypeRequestSpec.scala
@@ -16,15 +16,11 @@
 
 package bankaccountverification.web
 
-import bankaccountverification.connector.ReputationResponseEnum.{No, Yes}
-import bankaccountverification.connector.{BarsValidationResponse, ReputationResponseEnum}
 import com.codahale.metrics.SharedMetricRegistries
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.data.FormError
-import play.api.i18n.{Messages, MessagesApi}
 
 class AccountTypeRequestSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
 
@@ -34,8 +30,6 @@ class AccountTypeRequestSpec extends AnyWordSpec with Matchers with GuiceOneAppP
   }
 
   "AccountType form" should {
-    val messagesApi       = app.injector.instanceOf[MessagesApi]
-    implicit val messages: Messages = messagesApi.preferred(Seq())
 
     "validate personal successfully" when {
       "personal account is selected" in {

--- a/test/bankaccountverification/web/JourneyJsonSerializationSpec.scala
+++ b/test/bankaccountverification/web/JourneyJsonSerializationSpec.scala
@@ -16,15 +16,15 @@
 
 package bankaccountverification.web
 
-import bankaccountverification.connector.ReputationResponseEnum._
+import bankaccountverification.*
+import bankaccountverification.connector.ReputationResponseEnum.*
 import bankaccountverification.web.AccountTypeRequestEnum.{Business, Personal}
-import bankaccountverification._
 import org.bson.types.ObjectId
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 
-import java.time.{Clock, Instant, LocalDateTime, ZoneId}
+import java.time.{Clock, Instant, ZoneId}
 import scala.language.postfixOps
 
 class JourneyJsonSerializationSpec extends AnyWordSpec with Matchers {
@@ -52,7 +52,7 @@ class JourneyJsonSerializationSpec extends AnyWordSpec with Matchers {
         useNewGovUkServiceNavigation = Some(false)
       )
 
-      import Journey._
+      import Journey.*
 
       val personalJourneyJsValue = Json.toJson(personalJourney)
 
@@ -121,7 +121,7 @@ class JourneyJsonSerializationSpec extends AnyWordSpec with Matchers {
         useNewGovUkServiceNavigation = Some(false)
       )
 
-      import Journey._
+      import Journey.*
 
       val businessJourneyJsValue = Json.toJson(businessJourney)
 

--- a/test/bankaccountverification/web/VerificationServiceSpec.scala
+++ b/test/bankaccountverification/web/VerificationServiceSpec.scala
@@ -310,7 +310,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
     val assessResult = Future.successful(
       Success(BarsBusinessAssessSuccessResponse(Yes, Yes, None, Yes, Yes, No, No, Some(No), None, None)))
 
-    when(mockConnector.assessBusiness(any(), any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(assessResult)
+    when(mockConnector.assessBusiness(any(), any(), any(), any(), any(), any())(any(), any())).thenReturn(assessResult)
 
     "a valid address is provided" should {
       val inputAddress = Some(Address(List("line1", "line2"), Some("town"), Some("postcode")))
@@ -320,7 +320,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -333,7 +333,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq("12345678"), meq(None),
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq("12345678"), meq(None),
           meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -346,7 +346,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -361,7 +361,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -374,7 +374,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -387,7 +387,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -407,7 +407,6 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
         verify(mockConnector).assessBusiness(meq("Bob Company"),
-          meq(None),
           meq("203040"),
           meq("12345678"),
           meq(None),
@@ -430,7 +429,6 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
         verify(mockConnector).assessBusiness(meq("Bob Company"),
-          meq(None),
           meq("203040"),
           meq("12345678"),
           meq(None),
@@ -447,7 +445,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -462,7 +460,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         clearInvocations(mockConnector)
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }
@@ -474,7 +472,7 @@ class VerificationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       "modify the address to one with a single non-empty line" in {
         await(service.assessBusiness(userInput, inputAddress,"example-service"))
 
-        verify(mockConnector).assessBusiness(meq("Bob Company"), meq(None), meq("203040"), meq
+        verify(mockConnector).assessBusiness(meq("Bob Company"), meq("203040"), meq
         ("12345678"), meq(None), meq(expectedBarsAddress), meq("example-service"))(any(), any())
       }
     }

--- a/test/bankaccountverification/web/business/BusinessVerificationControllerSpec.scala
+++ b/test/bankaccountverification/web/business/BusinessVerificationControllerSpec.scala
@@ -16,17 +16,17 @@
 
 package bankaccountverification.web.business
 
-import org.apache.pekko.stream.Materializer
-import bankaccountverification._
+import bankaccountverification.*
 import bankaccountverification.connector.BarsBusinessAssessSuccessResponse
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Yes}
 import bankaccountverification.web.AccountTypeRequestEnum.Business
 import bankaccountverification.web.VerificationService
 import com.codahale.metrics.SharedMetricRegistries
+import org.apache.pekko.stream.Materializer
 import org.bson.types.ObjectId
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers.{eq => meq, _}
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{eq as meq, *}
+import org.mockito.Mockito.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -36,15 +36,15 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException}
 import uk.gov.hmrc.http.HttpException
 
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
@@ -76,7 +76,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
   "GET /verify/business" when {
     "the user is not logged in" should {
       val id = ObjectId.get()
-      val expiry = Instant.now.plus(60, ChronoUnit.MINUTES)
 
       "return 401" in {
         reset(mockAuthConnector)
@@ -361,8 +360,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
           .thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(formWithErrors))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
 
@@ -397,8 +394,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
 
@@ -434,8 +429,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
 
@@ -473,8 +466,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form.withError("Error", "a.specific.error")))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
           .withSession(Journey.callCountSessionKey -> "0")
@@ -505,8 +496,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form.withError("Error", "a.specific.error")))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
           .withSession(Journey.callCountSessionKey -> "1")
@@ -537,8 +526,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
           .withSession(Journey.callCountSessionKey -> "0")
@@ -570,8 +557,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
           .withSession(Journey.callCountSessionKey -> "1")
@@ -602,8 +587,6 @@ class BusinessVerificationControllerSpec extends AnyWordSpec with Matchers with 
         reset(mockService)
         when(mockService.assessBusiness(meq(data), any(), meq(serviceIdentifier))(any(), any())).thenReturn(Future.successful(Success(barsBusinessAssessResponse)))
         when(mockService.processBusinessAssessResponse(meq(id), any(), any(), any())(any(), any())).thenReturn(Future.successful(form))
-
-        import BusinessVerificationRequest.formats.bankAccountDetailsWrites
         val fakeRequest = FakeRequest("POST", s"/verify/business/${id.toHexString}")
           .withFormUrlEncodedBody(BusinessVerificationRequest.form.fill(data).data.toSeq : _*)
           .withSession(Journey.callCountSessionKey -> "1")

--- a/test/bankaccountverification/web/business/BusinessVerificationRequestSpec.scala
+++ b/test/bankaccountverification/web/business/BusinessVerificationRequestSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.data.FormError
-import play.api.i18n.{Messages, MessagesApi}
 
 import scala.language.postfixOps
 
@@ -37,8 +36,6 @@ class BusinessVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
   }
 
   "BankAccountDetails form" should {
-    val messagesApi       = app.injector.instanceOf[MessagesApi]
-    implicit val messages: Messages = messagesApi.preferred(Seq())
 
     "validate sortcode successfully" when {
       "sortcode is hyphenated" in {

--- a/test/bankaccountverification/web/personal/PersonalVerificationControllerSpec.scala
+++ b/test/bankaccountverification/web/personal/PersonalVerificationControllerSpec.scala
@@ -16,17 +16,17 @@
 
 package bankaccountverification.web.personal
 
-import org.apache.pekko.stream.Materializer
-import bankaccountverification._
+import bankaccountverification.*
 import bankaccountverification.connector.BarsPersonalAssessSuccessResponse
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Yes}
 import bankaccountverification.web.AccountTypeRequestEnum.Personal
 import bankaccountverification.web.VerificationService
 import com.codahale.metrics.SharedMetricRegistries
+import org.apache.pekko.stream.Materializer
 import org.bson.types.ObjectId
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers.{eq => meq, _}
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{eq as meq, *}
+import org.mockito.Mockito.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -36,16 +36,16 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException}
 import uk.gov.hmrc.http.HttpException
 
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 

--- a/test/bankaccountverification/web/personal/PersonalVerificationRequestSpec.scala
+++ b/test/bankaccountverification/web/personal/PersonalVerificationRequestSpec.scala
@@ -18,14 +18,13 @@ package bankaccountverification.web.personal
 
 import bankaccountverification.BACSRequirements
 import bankaccountverification.connector.ReputationResponseEnum.{Indeterminate, No, Partial, Yes}
-import bankaccountverification.connector.{BarsPersonalAssessBadRequestResponse, BarsPersonalAssessResponse, BarsPersonalAssessSuccessResponse, BarsValidationResponse, ReputationResponseEnum}
+import bankaccountverification.connector.{BarsPersonalAssessBadRequestResponse, BarsPersonalAssessSuccessResponse, ReputationResponseEnum}
 import com.codahale.metrics.SharedMetricRegistries
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.data.FormError
-import play.api.i18n.{Messages, MessagesApi}
 
 class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
 
@@ -35,8 +34,6 @@ class PersonalVerificationRequestSpec extends AnyWordSpec with Matchers with Gui
   }
 
   "BankAccountDetails form" should {
-    val messagesApi       = app.injector.instanceOf[MessagesApi]
-    implicit val messages: Messages = messagesApi.preferred(Seq())
 
     "validate sortcode successfully" when {
       "sortcode is hyphenated" in {


### PR DESCRIPTION
This pull request predominantly updates a dependency version in the `AppDependencies.scala` file (`bootstrapPlayVersion` from 10.5.0 to 10.7.0), which has been uplifted due to vulnerabilities mentioned in the catalogue application.

In addition:-

This pull request also focuses on improving code clarity and consistency by simplifying pattern matches, removing unused imports, and standardizing syntax across the codebase. It also includes minor formatting and cleanup in integration tests and template files.

**Pattern matching and error handling improvements:**
* Simplified pattern matches by replacing unused variables (e.g., `case Failure(e)` to `case Failure(_)`, `case Success(sc)` to `case Success(_)`) in controllers, services, and form validation for clearer intent and to avoid unnecessary variable bindings. [[1]](diffhunk://#diff-a7c13a6888a7fa5fe8da86000e00a51d23323d549f24b2a4b5e8d4576a14932bL98-R98) [[2]](diffhunk://#diff-9176ccc685c1f468f181ef4deb9c168bcee1efe290223080f6d837e8d3a382c6L134-R134) [[3]](diffhunk://#diff-d0198256a3664cfdefb0a774b1a67e35d3ec497f01749cc85b427fc5b72f60c1L134-R134) [[4]](diffhunk://#diff-fdb3c835ec9409f2eba76bce7d9b1d89400439c2f77ba1169ded66955755470eL106-R106) [[5]](diffhunk://#diff-f371b9e58d1f1626fc39983c87f80c80455e7ba897bbe6d2e2017f6659e746fbL59-L68) [[6]](diffhunk://#diff-f371b9e58d1f1626fc39983c87f80c80455e7ba897bbe6d2e2017f6659e746fbL94-L103) [[7]](diffhunk://#diff-125f5f458ce245ae700c45b81adbab0dc8b77c117fe62d8a084bb08b9197809dL53-R53)
* Removed unused `import` statements in several files to keep imports clean and reduce clutter. [[1]](diffhunk://#diff-ffbfcd4059e78cfeff87cac0b4c7dadc05200717808855af0ec307a81ca60708L46-R46) [[2]](diffhunk://#diff-e3959ad296d7b04bf2b5b2039640bfb27851b8770d62eed31a2dd588de524910L24-R24) [[3]](diffhunk://#diff-607fe4d2573b0ee054047cc2d70bbdb912e5e9abc2030af9f45beb129b5bdcc7L24-R24)

**Test and template cleanup:**
* Removed unnecessary variable assignments and unused imports in integration test specs, streamlining test code and improving readability. [[1]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L100-R100) [[2]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L114-R114) [[3]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L126) [[4]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L184-R183) [[5]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L198-R197) [[6]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L210-R209) [[7]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L267-R266) [[8]](diffhunk://#diff-aa3780c1ad07cfc7324656090b49e711e5e6c13eaf8348145cb009ff56fc7003L280) [[9]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L98-R98) [[10]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L112-R112) [[11]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L124) [[12]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L166-R165) [[13]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L180-R179) [[14]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L192-R191) [[15]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L232-R231) [[16]](diffhunk://#diff-1c341696b8871dba7916c876b6d4bf148088ee6276218e96cda69b6a3f308a88L245) [[17]](diffhunk://#diff-c33fe24eb28cd95f9afe65c53f294a796277cc275a9025773b74fcb8d8b3b7abL98-R98) [[18]](diffhunk://#diff-c33fe24eb28cd95f9afe65c53f294a796277cc275a9025773b74fcb8d8b3b7abL112-R112) [[19]](diffhunk://#diff-c33fe24eb28cd95f9afe65c53f294a796277cc275a9025773b74fcb8d8b3b7abL124) [[20]](diffhunk://#diff-c33fe24eb28cd95f9afe65c53f294a796277cc275a9025773b74fcb8d8b3b7abL166-R165)
* Standardized arrow syntax in Scala template files from `⇒` to `=>` for consistency and compatibility. [[1]](diffhunk://#diff-a28c095c977cfaee23b69003f8e0612a7aeacac9ea987455b8ef6dd7613290c1L37-R37) [[2]](diffhunk://#diff-98f7ca144174c27a2c66438eb5b9d486aaf0ecebf41d742dd0c948e5b2ac8083L67-R68)